### PR TITLE
Fix func_breakables with 0 health having no health

### DIFF
--- a/gamemodes/hideandseek/entities/weapons/has_hands/shared.lua
+++ b/gamemodes/hideandseek/entities/weapons/has_hands/shared.lua
@@ -38,7 +38,7 @@ function SWEP:PrimaryAttack()
 	local dist = ent.StartPos:DistToSqr(ent.HitPos)
 	ent = ent.Entity
 
-	if (ent:GetClass() == "func_breakable" || ent:GetClass() == "func_breakable_surf") && dist <= 10000 then
+	if (ent:GetClass() == "func_breakable" || ent:GetClass() == "func_breakable_surf") && dist <= 10000 && ent:Health() != 0 then
 		-- Damage
 		ent:EmitSound("physics/body/body_medium_impact_hard")
 		ent:Fire("RemoveHealth", 25)


### PR DESCRIPTION
Fix func_breakables with a health value of 0 breaking instantly, instead of having infinite health.

This might make some spots impossible on maps that aren't made for hide and seek.