### PR TITLE
Fix server crashing on player join

### DIFF
--- a/gamemodes/hideandseek/gamemode/sv_player.lua
+++ b/gamemodes/hideandseek/gamemode/sv_player.lua
@@ -7,12 +7,13 @@ function GM:PlayerInitialSpawn(ply)
 	if ply:IsBot() then
 		ply:SetTeam(TEAM_SEEK)
 		ply.Achs = {}
-		return
 	end
-	ply:SetTeam(TEAM_SPECTATOR)
 end
 
 function GM:HASPlayerNetReady(ply)
+	-- Setting a non bot player's team in GM:PlayerInitialSpawn() causes the server to crash, so we do it here
+	ply:SetTeam(TEAM_SPECTATOR)
+	
 	-- Get achievements from sql and also network etc
 	ply:ProcessAchievements()
 	-- Send round info


### PR DESCRIPTION
Calling ply:SetTeam() on a non bot player inside of GM:PlayerInitialSpawn() causes the server to crash, so do it in GM:HASPlayerNetReady() instead